### PR TITLE
[feature] 웹 애플리케이션과 싱글톤

### DIFF
--- a/src/test/java/hello/core/singleton/SingletonTest.java
+++ b/src/test/java/hello/core/singleton/SingletonTest.java
@@ -1,0 +1,29 @@
+package hello.core.singleton;
+
+import hello.core.AppConfig;
+import hello.core.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SingletonTest {
+
+    @Test
+    @DisplayName("스프링 없는 순수한 DI 컨테이너")
+    void pureContainer() {
+        AppConfig appConfig = new AppConfig();
+
+        //1. 조회 : 호출할 때 마다 객체를 생성
+        MemberService memberService1 = appConfig.memberService();
+
+        //2. 조회 : 호출할 때 마다 객체를 생성
+        MemberService memberService2 = appConfig.memberService();
+
+        //참조값이 다른 것을 확인
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+
+        //memberService1 =/ memberService2
+        Assertions.assertThat(memberService1).isNotSameAs(memberService2);
+    }
+}


### PR DESCRIPTION
SingletonTest : 우리가 만들었던 순수한 DI컨테이너인 AppConfig는 요청을 할 때마다 새로운 객체를 생성한다. -> 메모리 낭비가 심하다.
=> 해결 방안 : 해당 객체가 딱 1개만 생성되고 공유하도록 설계(싱글톤)